### PR TITLE
Night Forest Mobile Responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "prettier": "~3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^4.0.0",
-        "tw-animate-css": "^1.2.8",
+        "tw-animate-css": "^1.2.9",
         "typescript": "~5.5.4",
         "typescript-eslint": "~8.0.0"
       }
@@ -5089,9 +5089,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tw-animate-css": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.2.8.tgz",
-      "integrity": "sha512-AxSnYRvyFnAiZCUndS3zQZhNfV/B77ZhJ+O7d3K6wfg/jKJY+yv6ahuyXwnyaYA9UdLqnpCwhTRv9pPTBnPR2g==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.2.9.tgz",
+      "integrity": "sha512-9O4k1at9pMQff9EAcCEuy1UNO43JmaPQvq+0lwza9Y0BQ6LB38NiMj+qHqjoQf40355MX+gs6wtlR6H9WsSXFg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "~3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^4.0.0",
-    "tw-animate-css": "^1.2.8",
+    "tw-animate-css": "^1.2.9",
     "typescript": "~5.5.4",
     "typescript-eslint": "~8.0.0"
   },

--- a/src/components/Gallery/NightForest.tsx
+++ b/src/components/Gallery/NightForest.tsx
@@ -12,10 +12,10 @@ const NightForest = () => {
         boxColor="bg-3d-red-primary"
         boxShadow="shadow-3d-red-secondary"
         boxPadding="px-4 py-2 md:px-6 md:py-3 lg:px-8 lg:py-3"
-        custom_style="absolute top-[5%] right-[5%] md:top-[8%] md:right-[8%] lg:top-[10%] lg:right-[10%] text-sm md:text-xl lg:text-3xl text-white z-50 text-center md:text-right max-w-[90%] md:max-w-[50%]"
+        custom_style="absolute top-[5%] right-[5%] md:top-[8%] md:right-[8%] lg:top-[10%] lg:right-[10%] text-sm md:text-xl lg:text-3xl text-center text-white z-50  max-w-[90%] md:max-w-[50%]"
       >
-        Interested in seeing and learning <br />
-        more about our models?
+        <p>Interested in seeing and learning</p>
+        <p>more about our models?</p>
       </BoxShadow>
 
       <BoxShadow

--- a/src/components/Gallery/NightForest.tsx
+++ b/src/components/Gallery/NightForest.tsx
@@ -5,14 +5,14 @@ import BoxShadow from "../BoxShadow";
 
 const NightForest = () => {
   return (
-    <div className="relative">
+    <div className="relative w-full">
       <Image src={Forest} alt="Night Forest" className="h-auto w-full" />
 
       <BoxShadow
         boxColor="bg-3d-red-primary"
         boxShadow="shadow-3d-red-secondary"
-        boxPadding="px-8 py-3"
-        custom_style="absolute top-[10%] left-[42%] text-5xl text-white z-50"
+        boxPadding="px-4 py-2 md:px-6 md:py-3 lg:px-8 lg:py-3"
+        custom_style="absolute top-[5%] right-[5%] md:top-[8%] md:right-[8%] lg:top-[10%] lg:right-[10%] text-sm md:text-xl lg:text-3xl text-white z-50 text-center md:text-right max-w-[90%] md:max-w-[50%]"
       >
         Interested in seeing and learning <br />
         more about our models?
@@ -21,8 +21,8 @@ const NightForest = () => {
       <BoxShadow
         boxColor="bg-3d-red-primary"
         boxShadow="shadow-3d-red-secondary"
-        boxPadding="px-6 py-5"
-        custom_style="absolute bottom-[10%] left-[6%] text-5xl text-white z-50 underline underline-offset-4"
+        boxPadding="px-3 py-2 md:px-4 md:py-3 lg:px-6 lg:py-5"
+        custom_style="absolute bottom-[5%] left-[5%] md:bottom-[8%] md:left-[6%] lg:bottom-[10%] lg:left-[6%] text-sm md:text-xl lg:text-5xl text-white z-50 underline underline-offset-4"
       >
         <Link
           href={


### PR DESCRIPTION
![Screenshot 2025-05-12 171010](https://github.com/user-attachments/assets/c00a0b88-3f06-4e62-a052-51b9381f1a57)

Added responsiveness for night forest section, works for iPhone SE and semi-larger screens. 

There's an issue with spacing from footer when on iPhone though, do you want it to be spaced?